### PR TITLE
Added groups and updateinfo tags into repmod.xml

### DIFF
--- a/dtmrepo
+++ b/dtmrepo
@@ -358,10 +358,12 @@ gen_repodata() {
     flock -w ${LOCKWAIT} 1001 || genrepo_lock_error ${_DESTDIR}
     find ${_DESTDIR} -name '*.rpm' -empty -exec rm {} \;
     if [ "${_REPOID:0:${#LOCALMARKER}}" == "${LOCALMARKER}" -o "${_PROTECTREPO}" -eq 1 ]; then
-        createrepo ${_FORCE} ${_VERBOSE} -s sha --simple-md-filenames --basedir ${_DESTDIR} -o ${_DESTDIR} ${_DESTDIR}
+        createrepo ${_FORCE} ${_VERBOSE} -s sha --simple-md-filenames --basedir ${_DESTDIR} -o ${_DESTDIR} ${_DESTDIR} -g ${_DESTDIR}/comps.xml
+	modifyrepo --mdtype=updateinfo ${_DESTDIR}/*updateinfo.xml.gz ${_DESTDIR}/repodata/
     else
         repomanage -c -o -k ${keep} ${_DESTDIR} | egrep -v "${_PROTECT}" | xargs rm -f
-        createrepo ${_FORCE} ${_VERBOSE} -s sha --simple-md-filenames --basedir ${_DESTDIR} -o ${_DESTDIR} ${_DESTDIR}
+        createrepo ${_FORCE} ${_VERBOSE} -s sha --simple-md-filenames --basedir ${_DESTDIR} -o ${_DESTDIR} ${_DESTDIR} -g ${_DESTDIR}/comps.xml
+	modifyrepo --mdtype=updateinfo ${_DESTDIR}/*updateinfo.xml.gz ${_DESTDIR}/repodata/
     fi
     ) 1001> ${_LOCKFILE}
 


### PR DESCRIPTION
Repmod now contains all the metadata, including groups composition and udateinfo (errata) tags with the appropriate file locations.
With this change, repo can be imported straight to spacewalk with all metadata included.